### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/secrets.yml
+++ b/.github/workflows/secrets.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Secrets
 
 on: 


### PR DESCRIPTION
Potential fix for [https://github.com/rober0/HealenthClinica-Django/security/code-scanning/1](https://github.com/rober0/HealenthClinica-Django/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow, either at the root level (applies to all jobs) or at the job level (applies only to the specific job). Since the workflow only reads secrets and echoes them, it does not require any write permissions. The minimal safe setting is `contents: read`, which allows the workflow to read repository contents if needed, but not to write. You should add the following block at the top level of the workflow (after `name:` and before `on:`), or inside the `my_secrets` job. The best practice is to add it at the root level so all jobs inherit the least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
